### PR TITLE
test: try to set legacy providers on .cnf files

### DIFF
--- a/openssl/nodejs-openssl.cnf
+++ b/openssl/nodejs-openssl.cnf
@@ -14,6 +14,8 @@ providers = provider_sect
 # List of providers to load
 [provider_sect]
 default = default_sect
+legacy = legacy_sect
+
 # The fips section name should match the section name inside the
 # included fipsmodule.cnf.
 # fips = fips_sect
@@ -27,4 +29,7 @@ default = default_sect
 # OpenSSL may not work correctly which could lead to significant system
 # problems including inability to remotely access the system.
 [default_sect]
-# activate = 1
+activate = 1
+
+[legacy_sect]
+activate = 1

--- a/openssl/openssl/apps/openssl.cnf
+++ b/openssl/openssl/apps/openssl.cnf
@@ -52,6 +52,7 @@ tsa_policy3 = 1.2.3.4.5.7
 
 [openssl_init]
 providers = provider_sect
+legacy = legacy_sect
 
 # List of providers to load
 [provider_sect]
@@ -68,9 +69,11 @@ default = default_sect
 # becomes unavailable in openssl.  As a consequence applications depending on
 # OpenSSL may not work correctly which could lead to significant system
 # problems including inability to remotely access the system.
-[default_sect]
-# activate = 1
+[[default_sect]
+activate = 1
 
+[legacy_sect]
+activate = 1
 
 ####################################################################
 [ ca ]


### PR DESCRIPTION
Trying to follow-up https://github.com/notjaywu/curl-for-windows/pull/1 by also setting providers on openssl related .cnf files